### PR TITLE
Don't fake php version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "rss": "https://craftcms.com/changelog.rss"
   },
   "require": {
+    "php": "^7.0",
     "craftcms/cms": "^3.0.0",
     "vlucas/phpdotenv": "^2.4.0"
   },
@@ -28,10 +29,7 @@
     }
   },
   "config": {
-    "optimize-autoloader": true,
-    "platform": {
-      "php": "7.0"
-    }
+    "optimize-autoloader": true
   },
   "scripts": {
     "post-root-package-install": [


### PR DESCRIPTION
The "fake php version 7.0" prevents depencencies with other/higher requirements, e.g. `php: "^7.1"`, even if the higher version is installed.

https://github.com/fortrabbit/craft-copy/blob/ad6c2204a01f05031df4f417ae78aeeb7403b09f/composer.json#L24-L26

```
Could not find package fortrabbit/craft-copy in any version matching your PHP version (7.0.0.0)
```

Instead of `config/platfrom/php: "7.0"` we should use `require/php: "^7.0"`.
