### PR TITLE
Add composer config to sort packages

### DIFF
--- a/composer.json.default
+++ b/composer.json.default
@@ -9,6 +9,7 @@
     }
   },
   "config": {
+    "sort-packages": true,
     "optimize-autoloader": true,
     "platform": {
       "php": "7.0"


### PR DESCRIPTION
Super minor change but I feel this makes looking through the packages you have installed a lot easier.
If enable, this will sort installed packages by name as per the [documentation](https://getcomposer.org/doc/06-config.md#sort-packages).