### PR TITLE
Update general.php

### DIFF
--- a/config/general.php
+++ b/config/general.php
@@ -5,7 +5,7 @@
  * All of your system's general configuration settings go in here. You can see a
  * list of the available settings in vendor/craftcms/cms/src/config/GeneralConfig.php.
  *
- * @see craft\config\GeneralConfig
+ * @see \craft\config\GeneralConfig
  */
 
 return [


### PR DESCRIPTION
Without the backslash I wasn’t able to use “Navigate to declaration” in PhpStorm 2018.3