### PR TITLE
Allow for removal of vlucas/phpdotenv

### DIFF
--- a/craft
+++ b/craft
@@ -12,7 +12,7 @@ define('CRAFT_VENDOR_PATH', CRAFT_BASE_PATH.'/vendor');
 require_once CRAFT_VENDOR_PATH.'/autoload.php';
 
 // Load dotenv?
-if (file_exists(CRAFT_BASE_PATH.'/.env')) {
+if (class_exists('Dotenv\Dotenv') && file_exists(CRAFT_BASE_PATH.'/.env')) {
     (new Dotenv\Dotenv(CRAFT_BASE_PATH))->load();
 }
 

--- a/web/index.php
+++ b/web/index.php
@@ -11,7 +11,7 @@ define('CRAFT_VENDOR_PATH', CRAFT_BASE_PATH.'/vendor');
 require_once CRAFT_VENDOR_PATH.'/autoload.php';
 
 // Load dotenv?
-if (file_exists(CRAFT_BASE_PATH.'/.env')) {
+if (class_exists('Dotenv\Dotenv') && file_exists(CRAFT_BASE_PATH.'/.env')) {
     (new Dotenv\Dotenv(CRAFT_BASE_PATH))->load();
 }
 


### PR DESCRIPTION
We use `env_file: .env` in docker for all our Craft sites, which allows us to remove the `vlucas/phpdotenv` dependency. This pull request adds checks to ensure the `Dotenv` class exists before use.