### PR TITLE
Adds repoducable docker builds

### DIFF
--- a/.docker/000-default.conf
+++ b/.docker/000-default.conf
@@ -1,0 +1,10 @@
+<VirtualHost *:80>
+    <IfModule mod_setenvif.c>
+        SetEnvIf X-Forwarded-Proto "^https$" HTTPS
+    </IfModule>
+
+  	DocumentRoot /var/www/html/web
+
+    ErrorLog /dev/stderr
+    TransferLog /dev/stdout
+</VirtualHost>

--- a/.docker/opcache.ini
+++ b/.docker/opcache.ini
@@ -1,0 +1,11 @@
+[opcache]
+
+opcache.enable=${PHP_OPCACHE_ENABLE}
+opcache.revalidate_freq=0
+opcache.validate_timestamps=${PHP_OPCACHE_VALIDATE_TIMESTAMPS}
+opcache.max_accelerated_files=${PHP_OPCACHE_MAX_ACCELERATED_FILES}
+opcache.memory_consumption=${PHP_OPCACHE_MEMORY_CONSUMPTION}
+opcache.max_wasted_percentage=${PHP_OPCACHE_MAX_WASTED_PERCENTAGE}
+opcache.interned_strings_buffer=16
+
+opcache.fast_shutdown=1

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+vendor
+docker-compose.yml
+Dockerfile
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# composer
+FROM composer as vendor
+COPY composer.json composer.json
+COPY composer.lock composer.lock
+RUN composer install --ignore-platform-reqs --no-interaction --no-plugins --no-scripts --prefer-dist
+
+# node
+# FROM node:10-alpine as frontend
+# RUN mkdir -p /app/web
+# COPY package.json package-lock.json tailwind-config.js /app/
+# COPY resources /app/resources
+# WORKDIR /app
+# RUN npm install && npm production
+
+# apache
+FROM php:7.3-apache-stretch
+RUN apt-get update && apt-get install -y zlib1g-dev libpng-dev libpq-dev libzip-dev libicu-dev
+RUN docker-php-source extract && docker-php-ext-install pdo pdo_mysql pdo_pgsql intl zip bcmath gd && docker-php-source delete
+RUN sed -ri -e 's!/var/www/!/var/www/html/web!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf && \
+    sed -ri -e 's!/var/www/html!/var/www/html/web!g' /etc/apache2/sites-available/*.conf && a2enmod rewrite
+RUN if [ "$ENV" == "production" ]; then mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini; else mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini; fi
+RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 10M/g' $PHP_INI_DIR/php.ini
+RUN sed -i 's/memory_limit = 128M/memory_limit = 256M/g' $PHP_INI_DIR/php.ini
+RUN sed -i 's/max_execution_time = 30/max_execution_time = 120/g' $PHP_INI_DIR/php.ini
+COPY .docker/000-default.conf /etc/apache2/sites-enabled
+COPY --chown=www-data:www-data . /var/www/html
+COPY --chown=www-data:www-data --from=vendor /app/vendor/ /var/www/html/vendor/
+# COPY --from=frontend /app/web/js/ /var/www/html/web/js/
+# COPY --from=frontend /app/web/css/ /var/www/html/web/css/
+# COPY --from=frontend /app/mix-manifest.json /var/www/html/mix-manifest.json
+RUN chmod -R 777 /var/www/html/storage /var/www/html/web/cpresources /var/www/html/vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,27 @@
-# composer
 FROM composer as vendor
+COPY modules modules
 COPY composer.json composer.json
 COPY composer.lock composer.lock
-RUN composer install --ignore-platform-reqs --no-interaction --no-plugins --no-scripts --prefer-dist
+RUN composer install --ignore-platform-reqs --no-interaction --prefer-dist
 
-# node
-# FROM node:10-alpine as frontend
-# RUN mkdir -p /app/web
-# COPY package.json package-lock.json tailwind-config.js /app/
-# COPY resources /app/resources
-# WORKDIR /app
-# RUN npm install && npm production
-
-# apache
 FROM php:7.3-apache-stretch
-RUN apt-get update && apt-get install -y zlib1g-dev libpng-dev libpq-dev libzip-dev libicu-dev
-RUN docker-php-source extract && docker-php-ext-install pdo pdo_mysql pdo_pgsql intl zip bcmath gd && docker-php-source delete
+ENV PHP_OPCACHE_ENABLE="1" \
+    PHP_OPCACHE_VALIDATE_TIMESTAMPS="0" \
+    PHP_OPCACHE_MAX_ACCELERATED_FILES="10000" \
+    PHP_OPCACHE_MEMORY_CONSUMPTION="192" \
+    PHP_OPCACHE_MAX_WASTED_PERCENTAGE="10"
+COPY .docker/opcache.ini /usr/local/etc/php/conf.d/opcache.ini
+RUN apt-get update && apt-get install -y --no-install-recommends lsb-release zlib1g-dev libpng-dev libjpeg-dev libpq-dev libzip-dev libicu-dev libmagickwand-dev mysql-client && pecl install imagick
+RUN docker-php-source extract && docker-php-ext-install pdo pdo_mysql intl zip bcmath gd opcache && docker-php-ext-enable imagick && docker-php-source delete
 RUN sed -ri -e 's!/var/www/!/var/www/html/web!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf && \
     sed -ri -e 's!/var/www/html!/var/www/html/web!g' /etc/apache2/sites-available/*.conf && a2enmod rewrite
-RUN if [ "$ENV" == "production" ]; then mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini; else mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini; fi
+RUN if [ "$APP_ENV" == "production" ]; then mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini; else mv $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini; fi
 RUN sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 10M/g' $PHP_INI_DIR/php.ini
 RUN sed -i 's/memory_limit = 128M/memory_limit = 256M/g' $PHP_INI_DIR/php.ini
 RUN sed -i 's/max_execution_time = 30/max_execution_time = 120/g' $PHP_INI_DIR/php.ini
 COPY .docker/000-default.conf /etc/apache2/sites-enabled
 COPY --chown=www-data:www-data . /var/www/html
 COPY --chown=www-data:www-data --from=vendor /app/vendor/ /var/www/html/vendor/
-# COPY --from=frontend /app/web/js/ /var/www/html/web/js/
-# COPY --from=frontend /app/web/css/ /var/www/html/web/css/
-# COPY --from=frontend /app/mix-manifest.json /var/www/html/mix-manifest.json
-RUN chmod -R 777 /var/www/html/storage /var/www/html/web/cpresources /var/www/html/vendor
+RUN chmod -R 777 /var/www/html/storage
+RUN chmod -R 777 /var/www/html/web/cpresources
+RUN chmod -R 777 /var/www/html/vendor

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,29 @@
+version: '3.1'
+services:
+  app:
+    image: craftcms
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 8000:80
+    volumes:
+      - .:/var/www/html:cached
+    env_file: .env
+  db:
+    image: postgres:11-alpine
+    ports:
+      - 54320:5432
+    environment:
+      POSTGRES_ROOT_PASSWORD: SuperPassword123456!
+      POSTGRES_DB: dev_craftcms
+      POSTGRES_USER: craftcms
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - db_data:/var/lib/postgresql/data
+  redis:
+    image: redis
+    ports:
+     - 63790:6379
+volumes:
+  db_data:


### PR DESCRIPTION
This PR addresses #5.

1. It includes a Dockerfile, with a multi-stage build for composer and node, with node commented out
2. Includes a `docker-compose.yaml` with `redis` and `postgres`
3. `.dockerignore` to reduce docker build times (by excluding node_modules and vendor directories)

