### PR TITLE
Don't expose .env variables to $_SERVER

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -12,7 +12,10 @@ require_once CRAFT_VENDOR_PATH.'/autoload.php';
 
 // Load dotenv?
 if (class_exists('Dotenv\Dotenv') && file_exists(CRAFT_BASE_PATH.'/.env')) {
-    Dotenv\Dotenv::create(CRAFT_BASE_PATH)->load();
+    $factory = new Dotenv\Environment\DotenvFactory([
+        new Dotenv\Environment\Adapter\PutenvAdapter(),
+    ]);
+    Dotenv\Dotenv::create(CRAFT_BASE_PATH, null, $factory)->load();
 }
 
 // Load and run Craft


### PR DESCRIPTION
This PR only sets `.env` variables using `putenv()` and does not set them on `$_SERVER` which could be considered a security issue if $_SERVER vars were leaked in logs etc.