### PR TITLE
Add default DB_DSN to db.php

### DIFF
--- a/config/db.php
+++ b/config/db.php
@@ -10,6 +10,16 @@
 
 use craft\helpers\App;
 
+if(App::env('DB_DSN')){
+    return [
+        'dsn' => App::env('DB_DSN'),
+        'user' => App::env('DB_USER'),
+        'password' => App::env('DB_PASSWORD'),
+        'schema' => App::env('DB_SCHEMA'),
+        'tablePrefix' => App::env('DB_TABLE_PREFIX'),
+    ];
+}
+  
 return [
     'driver' => App::env('DB_DRIVER'),
     'server' => App::env('DB_SERVER'),
@@ -20,3 +30,4 @@ return [
     'schema' => App::env('DB_SCHEMA'),
     'tablePrefix' => App::env('DB_TABLE_PREFIX'),
 ];
+  


### PR DESCRIPTION
Due to the changes made in https://github.com/craftcms/craft/commit/a8156797a3c9ee042a5eefa9d089968f672d2147 people might have started using `DB_DSN` as a default way of connecting to their database

But after commit https://github.com/craftcms/craft/commit/d6653d549158d152ed986562cd28ad987210b0b2 they have to start using the older `DB_DRIVER` again

This checks if `DB_DSN` is set and if so uses that, if not falls back to default `DB_DRIVER`
