### PR TITLE
fix: Fix Composer 2.2.0 error by adding `allow-plugins`

### DIFF
--- a/composer.json.default
+++ b/composer.json.default
@@ -12,6 +12,10 @@
     }
   },
   "config": {
+    "allow-plugins": {
+      "craftcms/plugin-installer": true,
+      "yiisoft/yii2-composer": true
+    },
     "sort-packages": true,
     "optimize-autoloader": true,
     "platform": {


### PR DESCRIPTION
Fix Composer [2.2.0 error](https://getcomposer.org/doc/06-config.md#allow-plugins) by adding `allow-plugins`

If you don't do this, with Composer 2.2.0 and later, you'll see a warning, and in non-interactive mode, the plugins will never be run, and the composer install will hang

<img width="863" alt="Screen Shot 2021-12-25 at 3 10 04 PM" src="https://user-images.githubusercontent.com/7570798/147392852-daa4b605-288c-4689-8845-5cb46d487a46.png">

Merry Christmas!