### PR TITLE
Better multi-env configs

### DIFF
--- a/.env.example.dev
+++ b/.env.example.dev
@@ -1,0 +1,23 @@
+# The application ID used to to uniquely store session and cache data, mutex locks, and more
+CRAFT_APP_ID=
+
+# The environment Craft is currently running in (dev, staging, production, etc.)
+CRAFT_ENVIRONMENT=dev
+
+# The secure key Craft will use for hashing and encrypting data
+CRAFT_SECURITY_KEY=
+
+# Database connection settings
+CRAFT_DB_DRIVER=mysql
+CRAFT_DB_SERVER=127.0.0.1
+CRAFT_DB_PORT=3306
+CRAFT_DB_DATABASE=
+CRAFT_DB_USER=root
+CRAFT_DB_PASSWORD=
+CRAFT_DB_SCHEMA=public
+CRAFT_DB_TABLE_PREFIX=
+
+# General settings (see config/general.php)
+DEV_MODE=true
+ALLOW_ADMIN_CHANGES=true
+DISALLOW_ROBOTS=true

--- a/.env.example.production
+++ b/.env.example.production
@@ -2,7 +2,7 @@
 CRAFT_APP_ID=
 
 # The environment Craft is currently running in (dev, staging, production, etc.)
-CRAFT_ENVIRONMENT=dev
+CRAFT_ENVIRONMENT=production
 
 # The secure key Craft will use for hashing and encrypting data
 CRAFT_SECURITY_KEY=
@@ -16,3 +16,8 @@ CRAFT_DB_USER=root
 CRAFT_DB_PASSWORD=
 CRAFT_DB_SCHEMA=public
 CRAFT_DB_TABLE_PREFIX=
+
+# General settings (see config/general.php)
+DEV_MODE=false
+ALLOW_ADMIN_CHANGES=false
+DISALLOW_ROBOTS=false

--- a/.env.example.staging
+++ b/.env.example.staging
@@ -1,0 +1,23 @@
+# The application ID used to to uniquely store session and cache data, mutex locks, and more
+CRAFT_APP_ID=
+
+# The environment Craft is currently running in (dev, staging, production, etc.)
+CRAFT_ENVIRONMENT=staging
+
+# The secure key Craft will use for hashing and encrypting data
+CRAFT_SECURITY_KEY=
+
+# Database connection settings
+CRAFT_DB_DRIVER=mysql
+CRAFT_DB_SERVER=127.0.0.1
+CRAFT_DB_PORT=3306
+CRAFT_DB_DATABASE=
+CRAFT_DB_USER=root
+CRAFT_DB_PASSWORD=
+CRAFT_DB_SCHEMA=public
+CRAFT_DB_TABLE_PREFIX=
+
+# General settings (see config/general.php)
+DEV_MODE=false
+ALLOW_ADMIN_CHANGES=false
+DISALLOW_ROBOTS=true

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "post-create-project-cmd": [
-      "@php -r \"file_exists('.env') || copy('.env.example', '.env');\"",
+      "@php -r \"file_exists('.env') || copy('.env.example.dev', '.env');\"",
       "@php -r \"unlink('composer.json');\"",
       "@php -r \"rename('composer.json.default', 'composer.json');\"",
       "@composer dump-autoload -o",

--- a/composer.json.default
+++ b/composer.json.default
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "post-root-package-install": [
-      "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+      "@php -r \"file_exists('.env') || copy('.env.example.dev', '.env');\""
     ]
   }
 }

--- a/config/general.php
+++ b/config/general.php
@@ -17,9 +17,9 @@ return GeneralConfig::create()
     // Prevent generated URLs from including "index.php"
     ->omitScriptNameInUrls()
     // Enable Dev Mode (see https://craftcms.com/guides/what-dev-mode-does)
-    ->devMode(App::env('DEV_MODE'))
+    ->devMode(App::env('DEV_MODE') ?? false)
     // Allow administrative changes
-    ->allowAdminChanges(App::env('ALLOW_ADMIN_CHANGES'))
+    ->allowAdminChanges(App::env('ALLOW_ADMIN_CHANGES') ?? false)
     // Disallow robots
-    ->disallowRobots(App::env('DISALLOW_ROBOTS'))
+    ->disallowRobots(App::env('DISALLOW_ROBOTS') ?? false)
 ;

--- a/config/general.php
+++ b/config/general.php
@@ -11,18 +11,15 @@
 use craft\config\GeneralConfig;
 use craft\helpers\App;
 
-$isDev = App::env('CRAFT_ENVIRONMENT') === 'dev';
-$isProd = App::env('CRAFT_ENVIRONMENT') === 'production';
-
 return GeneralConfig::create()
     // Set the default week start day for date pickers (0 = Sunday, 1 = Monday, etc.)
     ->defaultWeekStartDay(1)
     // Prevent generated URLs from including "index.php"
     ->omitScriptNameInUrls()
-    // Enable Dev Mode on the dev environment (see https://craftcms.com/guides/what-dev-mode-does)
-    ->devMode($isDev)
-    // Only allow administrative changes on the dev environment
-    ->allowAdminChanges($isDev)
-    // Disallow robots everywhere except the production environment
-    ->disallowRobots(!$isProd)
+    // Enable Dev Mode (see https://craftcms.com/guides/what-dev-mode-does)
+    ->devMode(App::env('DEV_MODE'))
+    // Allow administrative changes
+    ->allowAdminChanges(App::env('ALLOW_ADMIN_CHANGES'))
+    // Disallow robots
+    ->disallowRobots(App::env('DISALLOW_ROBOTS'))
 ;


### PR DESCRIPTION
This PR adjusts the way environment-specific config settings (`devMode`, `allowAdminChanges`, and `disallowRobots`) are configured for new Craft projects.

Instead of `config/general.php` being responsible for deciding their values based on `CRAFT_ENVIRONMENT`, each environment is now responsible for setting `DEV_MODE`, `ALLOW_ADMIN_CHANGES`, and `DISALLOW_ROBOTS` environment variables individually.

If any of the environment variables are missing, `config/general.php` will default the setting to `false`. In each case, that felt like the safest option if the developer had simply forgotten to set the environment variable.

The stock `.env.example` file has been copied to three separate files based on the common types of environments, with the recommended settings for each one:

File | `DEV_MODE` | `ALLOW_ADMIN_CHANGES` | `DISALLOW_ROBOTS`
---- | :--------- | :-------------------- | :----------------
`.env.example.dev` | `true` | `true` | `true`
`.env.example.staging` | `false` | `false` | `true`
`.env.example.production` | `false` | `false` | `false`

---

### Obligatory environment variable override mention…

It’s a little awkward that these environment variable names are so similar to the environment variable override names (`CRAFT_DEV_MODE` etc.). Had we gone with those, it wouldn’t have been necessary to pull the values in manually from `config/general.php` in the first place.

However it was decided that it’s more important to be able to see exactly which config settings are being used by glancing at `config/general.php`, than to avoid writing a couple lines of code.

That said, there’s nothing stopping an individual project from using the environment variable overrides if they want to.