### PR TITLE
Include redirects boilerplate

### DIFF
--- a/config/redirects.php
+++ b/config/redirects.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Redirection Rules
+ *
+ * [TODO: Short description about how they are triggered on 404s]
+ *
+ * Read all about Craft’s redirection behavior, here:
+ * https://craftcms.com/docs/5.x/system/routing.html#redirection
+ */
+
+return [
+
+];

--- a/config/redirects.php
+++ b/config/redirects.php
@@ -2,10 +2,31 @@
 /**
  * Redirection Rules
  *
- * [TODO: Short description about how they are triggered on 404s]
+ * Rules returned in this array are evaluated only after Craft would ordinarily
+ * throw a 404 exception. They can be key-value pairs representing “from”
+ * and “to” URIs…
  *
- * Read all about Craft’s redirection behavior, here:
- * https://craftcms.com/docs/5.x/system/routing.html#redirection
+ * ```php
+ * return [
+ *     'old/path' => 'new/path',
+ * ];
+ * ```
+ *
+ * …or a nested array with `from`, `to`, `caseSensitive`, and `statusCode` keys:
+ *
+ * ```php
+ * return [
+ *     [
+ *         'from' => 'Helpdesk.aspx',
+ *         'to' => 'account/tickets',
+ *         'caseSensitive' => true,
+ *         'statusCode' => 301,
+ *     ],
+ * ];
+ * ```
+ *
+ * Read all about Craft’s redirection behavior and capabilities, here:
+ * @link https://craftcms.com/docs/5.x/system/routing.html#redirection
  */
 
 return [

--- a/config/redirects.php
+++ b/config/redirects.php
@@ -29,6 +29,4 @@
  * @link https://craftcms.com/docs/5.x/system/routing.html#redirection
  */
 
-return [
-
-];
+return [];


### PR DESCRIPTION
### Description
Started this PR, but probably best for @AugustMiller to finish.

Some things to consider:

- Redirects might warrant their own page in the docs, instead of [nesting in Routing](https://craftcms.com/docs/5.x/system/routing.html#redirection). Cross-linking makes sense, but they work very differently from routes, they just happen to use the same pattern format.
- Seems a little odd that the heading on `config/routes.php` is "Site URL Rules". Why not "Routes" (matching the CP)?
- Docs search currently gives bad results for `redirect`.