### PR TITLE
Run `craft up` after `composer update`

### DIFF
--- a/composer.json.default
+++ b/composer.json.default
@@ -21,6 +21,7 @@
     }
   },
   "scripts": {
+    "post-update-cmd": "@php craft up",
     "post-root-package-install": [
       "@php -r \"file_exists('.env') || copy('.env.example.dev', '.env');\""
     ]


### PR DESCRIPTION
### Description
Should prevent lots of headaches, when people run `composer update` and forget to run `craft up` locally. If the update has migrations, the subsequent deploy may fail with mismatched schema versions.