### PR TITLE
Change dotenv loading to createImmutable

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -15,7 +15,6 @@ require_once CRAFT_VENDOR_PATH . '/autoload.php';
 
 // Load dotenv?
 if (class_exists(Dotenv\Dotenv::class)) {
-    // By default, this will allow .env file values to override environment variables
-    // with matching names. Use `createUnsafeImmutable` to disable this.
-    Dotenv\Dotenv::createUnsafeMutable(CRAFT_BASE_PATH)->safeLoad();
+    // Use `createMutable` to allow .env file overrides for existing environment variables.
+    Dotenv\Dotenv::createImmutable(CRAFT_BASE_PATH)->safeLoad();
 }


### PR DESCRIPTION
### Description
`createImmutable` is a better default.
`createUnsafeMutable` can get people into trouble, especially if they commit an `.env` file.